### PR TITLE
custom model create check to avoid configuration error 

### DIFF
--- a/src/datarobotx/idp/custom_models.py
+++ b/src/datarobotx/idp/custom_models.py
@@ -13,7 +13,7 @@
 
 # mypy: disable-error-code="attr-defined"
 # pyright: reportPrivateImportUsage=false
-from typing import Any
+from typing import Any, Union
 
 import datarobot as dr
 
@@ -26,11 +26,18 @@ def _find_existing_custom_model(**kwargs: Any) -> str:
 
 
 def get_or_create_custom_model(
-    endpoint: str, token: str, name: str, target_type: str, **kwargs: Any
+    endpoint: str,
+    token: str,
+    name: str,
+    target_type: Union[str, dr.enums.TARGET_TYPE],
+    **kwargs: Any,
 ) -> str:
     """Get or create a custom model with requested parameters."""
     dr.Client(endpoint=endpoint, token=token)
+
     try:
         return _find_existing_custom_model(name=name, target_type=target_type, **kwargs)
     except KeyError:
-        return str(dr.CustomInferenceModel.create(name=name, target_type=target_type, **kwargs).id)
+        return str(
+            dr.CustomInferenceModel.create(name=name, target_type=target_type, **kwargs).id  # type: ignore[arg-type]
+        )

--- a/src/datarobotx/idp/custom_models.py
+++ b/src/datarobotx/idp/custom_models.py
@@ -13,39 +13,9 @@
 
 # mypy: disable-error-code="attr-defined"
 # pyright: reportPrivateImportUsage=false
-import posixpath
-from typing import Any, Optional
-
-import requests
+from typing import Any
 
 import datarobot as dr
-from datarobot.rest import handle_http_error
-from datarobot.utils import camelize
-
-
-def _create_custom_model(
-    endpoint: str,
-    token: str,
-    name: str,
-    target_type: str,
-    custom_model_type: str = "inference",
-    target_name: Optional[str] = None,
-    **kwargs: Any,
-) -> str:
-    url = posixpath.join(endpoint, "customModels/")
-    body = {
-        "name": name,
-        "target_type": target_type,
-        "custom_model_type": custom_model_type,
-    }
-    if target_name:
-        body["custom_model_name"] = target_name
-    body.update(kwargs)
-    body = {camelize(k): v for k, v in body.items()}
-    resp = requests.post(url, headers={"Authorization": f"Bearer {token}"}, json=body)
-    if not resp:
-        handle_http_error(resp)
-    return str(resp.json()["id"])
 
 
 def _find_existing_custom_model(**kwargs: Any) -> str:
@@ -56,27 +26,11 @@ def _find_existing_custom_model(**kwargs: Any) -> str:
 
 
 def get_or_create_custom_model(
-    endpoint: str,
-    token: str,
-    name: str,
-    target_type: str,
-    target_name: Optional[str] = None,
-    **kwargs: Any,
+    endpoint: str, token: str, name: str, target_type: str, **kwargs: Any
 ) -> str:
     """Get or create a custom model with requested parameters."""
-    if target_type != "training" and target_name is None and target_type != "Anomaly":
-        raise ValueError(
-            "target_name is required for inference custom models that are not Anomaly Detection Models"
-        )
     dr.Client(endpoint=endpoint, token=token)
     try:
         return _find_existing_custom_model(name=name, target_type=target_type, **kwargs)
     except KeyError:
-        return _create_custom_model(
-            endpoint=endpoint,
-            token=token,
-            name=name,
-            target_type=target_type,
-            target_name=target_name,
-            **kwargs,
-        )
+        return str(dr.CustomInferenceModel.create(name=name, target_type=target_type, **kwargs).id)

--- a/tests/integration/test_custom_models.py
+++ b/tests/integration/test_custom_models.py
@@ -33,7 +33,12 @@ def test_get_or_create(dr_endpoint, dr_token, cleanup_env):
     )
     assert model_id_1 == model_id_2
 
+    with pytest.raises(ValueError):
+        model_id_3 = get_or_create_custom_model(
+            dr_endpoint, dr_token, "pytest model #2", "TextGeneration"
+        )
+
     model_id_3 = get_or_create_custom_model(
-        dr_endpoint, dr_token, "pytest model #2", "TextGeneration"
+        dr_endpoint, dr_token, "pytest model #2", "TextGeneration", target_name="bar"
     )
     assert model_id_1 != model_id_3


### PR DESCRIPTION
As outlined in https://datarobot.slack.com/archives/C067KF6USDT/p1714039022065149 custom inference models require a target name