### PR TITLE
Marshall add debug mode to pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,16 @@ import os
 import pytest
 
 
+def pytest_addoption(parser):
+    """Parse command line arguments."""
+    parser.addoption(
+        "--debug_override",
+        action="store",
+        default=False,
+        help="When set, will not delete test results when done.",
+    )
+
+
 @pytest.fixture(scope="module")
 def dr_token():
     """DR api token."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,6 +21,11 @@ import datarobot as dr
 from datarobot.utils.pagination import unpaginate
 
 
+@pytest.fixture(scope="session")
+def debug_override(pytestconfig):
+    return pytestconfig.getoption("debug_override")
+
+
 @pytest.fixture(scope="module")
 def cleanup_dr(dr_endpoint, dr_token):
     """Build a context manager for cleaning up DR assets."""

--- a/tests/integration/test_credentials.py
+++ b/tests/integration/test_credentials.py
@@ -17,8 +17,8 @@ from datarobotx.idp.credentials import get_replace_or_create_credential
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("credentials/", id_attribute="credentialId"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("credentials/", id_attribute="credentialId", debug_override=debug_override):
         yield
 
 

--- a/tests/integration/test_custom_models.py
+++ b/tests/integration/test_custom_models.py
@@ -17,8 +17,8 @@ from datarobotx.idp.custom_models import get_or_create_custom_model
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("customModels/"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("customModels/", debug_override=debug_override):
         yield
 
 

--- a/tests/integration/test_datasets.py
+++ b/tests/integration/test_datasets.py
@@ -37,8 +37,8 @@ def use_case(dr_endpoint, dr_token, cleanup_dr):
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("datasets/", id_attribute="datasetId"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("datasets/", id_attribute="datasetId", debug_override=debug_override):
         yield
 
 

--- a/tests/integration/test_datastore.py
+++ b/tests/integration/test_datastore.py
@@ -27,8 +27,8 @@ def canonical_name_2():
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("externalDataStores/"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("externalDataStores/", debug_override):
         yield
 
 

--- a/tests/integration/test_execution_environments.py
+++ b/tests/integration/test_execution_environments.py
@@ -17,8 +17,8 @@ from datarobotx.idp.execution_environments import get_or_create_execution_enviro
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("executionEnvironments/"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("executionEnvironments/", debug_override=debug_override):
         yield
 
 

--- a/tests/integration/test_llm_blueprints.py
+++ b/tests/integration/test_llm_blueprints.py
@@ -41,8 +41,8 @@ def playground(dr_endpoint, dr_token, cleanup_dr, use_case):
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr, playground):
-    with cleanup_dr("genai/llmBlueprints/", params={"playgroundId": playground}):
+def cleanup_env(cleanup_dr, playground, debug_override):
+    with cleanup_dr("genai/llmBlueprints/", params={"playgroundId": playground}, debug_override=debug_override):
         yield
 
 

--- a/tests/integration/test_playgrounds.py
+++ b/tests/integration/test_playgrounds.py
@@ -28,8 +28,8 @@ def use_case(dr_endpoint, dr_token, cleanup_dr):
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("genai/playgrounds/"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("genai/playgrounds/", debug_override=debug_override):
         yield
 
 

--- a/tests/integration/test_use_cases.py
+++ b/tests/integration/test_use_cases.py
@@ -17,8 +17,8 @@ from datarobotx.idp.use_cases import get_or_create_use_case
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("useCases/"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("useCases/", debug_override=debug_override):
         yield
 
 

--- a/tests/integration/test_vector_databases.py
+++ b/tests/integration/test_vector_databases.py
@@ -30,8 +30,8 @@ def use_case(dr_endpoint, dr_token, cleanup_dr):
 
 
 @pytest.fixture
-def cleanup_env(cleanup_dr):
-    with cleanup_dr("genai/vectorDatabases/"):
+def cleanup_env(cleanup_dr, debug_override):
+    with cleanup_dr("genai/vectorDatabases/", debug_override=debug_override):
         yield
 
 


### PR DESCRIPTION
## Summary
Now you can pytest -k test_idp_helper_here --debug_override=True to not delete pytest assets after your test

Note, if you use this, run something to remove your pytest assets when you're done!

## Rationale


### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
