### PR TITLE
update to new 3.4 dr client methods

### DIFF
--- a/src/datarobotx/idp/deployments.py
+++ b/src/datarobotx/idp/deployments.py
@@ -109,12 +109,9 @@ def get_replace_or_create_deployment_from_registered_model(
             curr_registered_model_id,
         ) = _lookup_registered_model_version(endpoint, token, curr_deployment_id)
         if registered_model_version_id != curr_registered_model_version_id:
-            model_id = (
-                dr.RegisteredModel.get(curr_registered_model_id)
-                .get_version(registered_model_version_id)
-                .model_id
+            dr.Deployment.get(curr_deployment_id).perform_model_replace(
+                new_registered_model_version_id=registered_model_version_id, reason=reason
             )
-            dr.Deployment.get(curr_deployment_id).perform_model_replace(model_id, reason=reason)
         return curr_deployment_id
     except KeyError:
         kwargs["description"] = kwargs.get("description", "") + f"\nChecksum: {deployment_token}"

--- a/tests/integration/test_datarobot_model_deployments.py
+++ b/tests/integration/test_datarobot_model_deployments.py
@@ -90,7 +90,7 @@ def recommended_model(autopilot_model):
 
 @pytest.fixture()
 def other_model(autopilot_model):
-    return dr.Project.get(autopilot_model).get_models()[1].id
+    return dr.Project.get(autopilot_model).get_model_records()[1].id
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

update to new 3.4 dr client methods
- deployments (use _new_registered_model_version_id_)
- test_deployments update _get_models_ to _get_model_records_

## Rationale


### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
