### PR TITLE
accommodate and test tempfile node return types

### DIFF
--- a/src/datarobotx/idp/common/path_dataset.py
+++ b/src/datarobotx/idp/common/path_dataset.py
@@ -117,13 +117,13 @@ class PathDataset(AbstractVersionedDataset):  # type: ignore
 
         return local_path
 
-    def _save(self, data: Union[Path, str, tempfile.TemporaryDirectory[Any]]) -> None:
+    def _save(self, data: Union[Path, str, tempfile.TemporaryDirectory[Any], tempfile.NamedTemporaryFile]) -> None:
         if isinstance(data, str):
             path = Path(data)
-        elif isinstance(data, tempfile.TemporaryDirectory):
-            path = Path(data.name)
-        else:
+        elif isinstance(data, Path):
             path = data
+        elif hasattr(data, "name"): # tempfile does not support isinstance checks https://bugs.python.org/issue33762
+            path = Path(data.name)
 
         assert path.is_file() or path.is_dir(), "Provided path must be a file or directory."
 

--- a/src/datarobotx/idp/common/path_dataset.py
+++ b/src/datarobotx/idp/common/path_dataset.py
@@ -117,12 +117,16 @@ class PathDataset(AbstractVersionedDataset):  # type: ignore
 
         return local_path
 
-    def _save(self, data: Union[Path, str, tempfile.TemporaryDirectory[Any], tempfile.NamedTemporaryFile]) -> None:
+    def _save(
+        self, data: Union[Path, str, tempfile.TemporaryDirectory[Any], tempfile.NamedTemporaryFile]
+    ) -> None:
         if isinstance(data, str):
             path = Path(data)
         elif isinstance(data, Path):
             path = data
-        elif hasattr(data, "name"): # tempfile does not support isinstance checks https://bugs.python.org/issue33762
+        elif hasattr(
+            data, "name"
+        ):  # tempfile does not support isinstance checks https://bugs.python.org/issue33762
             path = Path(data.name)
 
         assert path.is_file() or path.is_dir(), "Provided path must be a file or directory."

--- a/src/datarobotx/idp/common/path_dataset.py
+++ b/src/datarobotx/idp/common/path_dataset.py
@@ -118,7 +118,8 @@ class PathDataset(AbstractVersionedDataset):  # type: ignore
         return local_path
 
     def _save(
-        self, data: Union[Path, str, tempfile.TemporaryDirectory[Any], tempfile.NamedTemporaryFile]
+        self,
+        data: Union[Path, str, tempfile.TemporaryDirectory[Any], tempfile.NamedTemporaryFile],  # type: ignore
     ) -> None:
         if isinstance(data, str):
             path = Path(data)

--- a/tests/unit/test_path_dataset.py
+++ b/tests/unit/test_path_dataset.py
@@ -12,7 +12,7 @@
 # https://www.datarobot.com/wp-content/uploads/2021/07/DataRobot-Tool-and-Utility-Agreement.pdf
 
 from pathlib import Path
-from shutil import copytree, copy
+from shutil import copy, copytree
 import tempfile
 
 from kedro.io import DataCatalog

--- a/tests/unit/test_path_dataset.py
+++ b/tests/unit/test_path_dataset.py
@@ -55,7 +55,6 @@ def asset_path(request, pathlib_path):
         return f
 
 
-
 @pytest.fixture()
 def storage_path(tmp_path, pathlib_path):
     _, save_type = pathlib_path


### PR DESCRIPTION
## Summary
test and support the case where a custom node returns a tempfile to be persisted as a pathdataset

## Rationale
comes up if we want to perist e.g. model-metadata as a pathdataset

### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
