### PR TITLE
Calendar idp helpers

### DIFF
--- a/src/datarobotx/idp/autopilot.py
+++ b/src/datarobotx/idp/autopilot.py
@@ -31,13 +31,14 @@ def _find_existing_project(project_config_token: str) -> Optional[str]:
         raise KeyError("No matching project found") from exc
 
 
-def reconcile_config_dictionaries(
+def _reconcile_config_dictionaries(
     create_from_dataset_config: Optional[Dict[str, Any]] = None,
     analyze_and_model_config: Optional[Dict[str, Any]] = None,
     datetime_partitioning_config: Optional[Dict[str, Any]] = None,
     feature_settings_config: Optional[List[Dict[str, Any]]] = None,
     advanced_options_config: Optional[Dict[str, Any]] = None,
     use_case: Optional[str] = None,
+    calendar_id: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """
     Reconcile the configuration dictionaries and return a list of them.
@@ -58,6 +59,8 @@ def reconcile_config_dictionaries(
     use_case : str, optional
         The use case to build the project under, by default None.
         If provided, the project will exist under the usecase
+    calendar_id : str, optional
+        The calendar id to use for the project, by default None
     """
     # Make sure the user does not modify the original dictionaries
     serverside_create_from_dataset_config = (
@@ -78,6 +81,9 @@ def reconcile_config_dictionaries(
             serverside_datetime_partitioning_config["feature_settings"] = [
                 dr.FeatureSettings(**config) for config in feature_settings_config
             ]
+        if calendar_id is not None:
+            serverside_datetime_partitioning_config["calendar_id"] = calendar_id
+
         serverside_analyze_and_model_config[
             "partitioning_method"
         ] = dr.DatetimePartitioningSpecification(**serverside_datetime_partitioning_config)
@@ -136,6 +142,7 @@ def get_or_create_autopilot_run(
     advanced_options_config: Optional[Dict[str, Any]] = None,
     use_case: Optional[str] = None,
     user_defined_segment_id_columns: Optional[List[str]] = None,
+    calendar_id: Optional[str] = None,
 ) -> Optional[str]:
     """Get or create a new project with requested parameters.
 
@@ -163,6 +170,8 @@ def get_or_create_autopilot_run(
         If provided, the project will exist under the usecase
     user_defined_segment_id_columns : str, optional
         The column to use for segmented modeling (time series only), by default None
+    calendar_id : str, optional
+        The calendar id to use for the project, by default None
     """
     dr.Client(token=token, endpoint=endpoint)
 
@@ -187,13 +196,14 @@ def get_or_create_autopilot_run(
     except KeyError:
         pass
 
-    create_from_dataset_config, analyze_and_model_config = reconcile_config_dictionaries(
+    create_from_dataset_config, analyze_and_model_config = _reconcile_config_dictionaries(
         create_from_dataset_config,
         analyze_and_model_config,
         datetime_partitioning_config,
         feature_settings_config,
         advanced_options_config,
         use_case,
+        calendar_id,
     )
 
     project_name = f"{name} [{project_config_token}]"

--- a/src/datarobotx/idp/calendars.py
+++ b/src/datarobotx/idp/calendars.py
@@ -1,0 +1,106 @@
+# Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# DataRobot, Inc.
+#
+# This is proprietary source code of DataRobot, Inc. and its
+# affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+# https://www.datarobot.com/wp-content/uploads/2021/07/DataRobot-Tool-and-Utility-Agreement.pdf
+
+
+import datetime as dt
+from pathlib import Path
+from typing import Union
+
+import datarobot as dr
+from datarobot import CalendarFile  # type: ignore[attr-defined]
+
+from datarobotx.idp.common.hashing import get_hash
+
+
+def _find_existing_calendar(calendar_token: str) -> str:
+    for calendar in CalendarFile.list():
+        if calendar_token in str(calendar.name):
+            return str(calendar.id)
+    raise KeyError("No matching calendar found")
+
+
+def get_or_create_calendar_dataset_from_country_code(
+    endpoint: str,
+    token: str,
+    name: str,
+    country_code: str,
+    start_date: Union[str, dt.datetime],
+    end_date: Union[str, dt.datetime],
+) -> str:
+    """Create or retrieve a calendar dataset from a country code.
+
+    Parameters
+    ----------
+    name : str
+        Name for the calendar
+    country_code : str
+        The country code to use for the calendar.
+    start_date : str | datetime
+        The earliest date to include in the generated calendar.
+        If a string, it must be in the format 'YYYY-MM-DD'.
+    end_date : str | datetime
+        The latest date to include in the generated calendar.
+        If a string, it must be in the format 'YYYY-MM-DD'.
+
+    Returns
+    -------
+    str
+        The ID of the created or retrieved calendar.
+    """
+    dr.Client(token=token, endpoint=endpoint)  # type: ignore
+
+    calendar_token = get_hash(name, country_code, start_date, end_date)
+    try:
+        return _find_existing_calendar(calendar_token=calendar_token)
+    except KeyError:
+        if isinstance(start_date, str):
+            start_date = dt.datetime.strptime(start_date, "%Y-%m-%d")
+        if isinstance(end_date, str):
+            end_date = dt.datetime.strptime(end_date, "%Y-%m-%d")
+        calendar_id = str(
+            dr.CalendarFile.create_calendar_from_country_code(  # type: ignore[attr-defined]
+                country_code, start_date=start_date, end_date=end_date
+            ).id
+        )
+        dr.CalendarFile.update_name(calendar_id, new_calendar_name=f"{name} [{calendar_token}]")  # type: ignore[attr-defined]
+        return calendar_id
+
+
+def get_or_create_calendar_dataset_from_file(
+    endpoint: str,
+    token: str,
+    name: str,
+    file_path: str,
+) -> str:
+    """Create or retrieve a calendar dataset from a file.
+
+    Parameters
+    ----------
+    name : str
+        Name for the calendar
+    file_path : str
+        The path to the file to use for the calendar.
+
+    Returns
+    -------
+    str
+        The ID of the created or retrieved calendar.
+    """
+    dr.Client(token=token, endpoint=endpoint)  # type: ignore
+
+    calendar_token = get_hash(name, Path(file_path))
+    try:
+        return _find_existing_calendar(calendar_token=calendar_token)
+    except KeyError:
+        calendar_id = str(dr.CalendarFile.create(file_path).id)  # type: ignore[attr-defined]
+        dr.CalendarFile.update_name(calendar_id, new_calendar_name=f"{name} [{calendar_token}]")  # type: ignore[attr-defined]
+        return calendar_id

--- a/src/datarobotx/idp/common/hashing.py
+++ b/src/datarobotx/idp/common/hashing.py
@@ -13,6 +13,7 @@
 
 """Hashing utilities."""
 
+from datetime import date
 from hashlib import sha256
 import inspect
 import os
@@ -61,6 +62,8 @@ def get_hash(*args: Any, **kwargs: Any) -> str:
             arg = get_hash(**d).encode("utf-8")
         elif isinstance(arg, Sequence):
             arg = get_hash(*arg).encode("utf-8")
+        elif isinstance(arg, date):
+            arg = arg.isoformat().encode("utf-8")
         elif isinstance(arg, Path) and arg.is_file():
             with open(arg, "rb") as f:
                 arg = ""

--- a/tests/integration/test_autopilot.py
+++ b/tests/integration/test_autopilot.py
@@ -166,7 +166,6 @@ def test_get_or_create_autopilot_run(
     calendar_from_dataset,
     cleanup_projects,
 ):
-    datetime_partitioning_config["calendar_id"] = calendar_from_dataset
     project_id_1 = get_or_create_autopilot_run(
         dr_endpoint,
         dr_token,
@@ -177,6 +176,7 @@ def test_get_or_create_autopilot_run(
         feature_settings_config=feature_settings_config,
         advanced_options_config=advanced_options_config,
         use_case=use_case,
+        calendar_id=calendar_from_dataset,
     )
     assert len(project_id_1)
 
@@ -190,6 +190,7 @@ def test_get_or_create_autopilot_run(
         feature_settings_config=feature_settings_config,
         advanced_options_config=advanced_options_config,
         use_case=use_case,
+        calendar_id=calendar_from_dataset,
     )
 
     assert project_id_1 == project_id_2
@@ -206,6 +207,7 @@ def test_get_or_create_autopilot_run(
         feature_settings_config=feature_settings_config,
         advanced_options_config=advanced_options_config,
         use_case=use_case,
+        calendar_id=calendar_from_dataset,
     )
 
     assert project_id_1 != project_id_3

--- a/tests/integration/test_calendars.py
+++ b/tests/integration/test_calendars.py
@@ -1,0 +1,95 @@
+#
+# Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+# All rights reserved.
+#
+# DataRobot, Inc.
+#
+# This is proprietary source code of DataRobot, Inc. and its
+# affiliates.
+#
+# Released under the terms of DataRobot Tool and Utility Agreement.
+# https://www.datarobot.com/wp-content/uploads/2021/07/DataRobot-Tool-and-Utility-Agreement.pdf
+
+import datetime as dt
+
+import pandas as pd
+import pytest
+
+from datarobotx.idp.calendars import (
+    get_or_create_calendar_dataset_from_country_code,
+    get_or_create_calendar_dataset_from_file,
+)
+
+
+@pytest.fixture
+def cleanup_env(cleanup_dr):
+    with cleanup_dr("calendars/", id_attribute="Id"):
+        yield
+
+
+@pytest.fixture
+def dummy_calendar_file(tmp_path):
+    dummy_calendar = pd.DataFrame(
+        {
+            "Date": ["2024-01-01", "2024-12-25"],
+            "Name": ["New Year's Day", "Christmas Day"],
+        },
+    )
+    path = tmp_path / "py_test.csv"
+    dummy_calendar.to_csv(path, index=False)
+    return str(path)
+
+
+@pytest.fixture
+def dummy_generated_calendar():
+    return {
+        "country_code": "US",
+        "start_date": dt.date(2024, 1, 1),
+        "end_date": dt.date(2024, 12, 31),
+    }
+
+
+def test_get_or_create_from_file(dr_endpoint, dr_token, dummy_calendar_file, cleanup_dr):
+    ds_1 = get_or_create_calendar_dataset_from_file(
+        dr_endpoint,
+        dr_token,
+        "pytest calendar #1",
+        dummy_calendar_file,
+    )
+    assert len(ds_1)
+
+    ds_2 = get_or_create_calendar_dataset_from_file(
+        dr_endpoint,
+        dr_token,
+        "pytest calendar #1",
+        dummy_calendar_file,
+    )
+    assert ds_1 == ds_2
+
+    ds_3 = get_or_create_calendar_dataset_from_file(
+        dr_endpoint,
+        dr_token,
+        "pytest calendar #2",
+        dummy_calendar_file,
+    )
+    assert ds_1 != ds_3
+
+
+def test_get_or_create_from_country_code(
+    dr_endpoint, dr_token, dummy_generated_calendar, cleanup_dr
+):
+    ds_1 = get_or_create_calendar_dataset_from_country_code(
+        dr_endpoint, dr_token, "pytest calendar #1", **dummy_generated_calendar
+    )
+    assert len(ds_1)
+
+    ds_2 = get_or_create_calendar_dataset_from_country_code(
+        dr_endpoint, dr_token, "pytest calendar #1", **dummy_generated_calendar
+    )
+    assert ds_1 == ds_2
+
+    ds_3 = get_or_create_calendar_dataset_from_country_code(
+        dr_endpoint, dr_token, "pytest calendar #2", **dummy_generated_calendar
+    )
+    assert ds_1 != ds_3

--- a/tests/unit/test_hashing.py
+++ b/tests/unit/test_hashing.py
@@ -92,6 +92,10 @@ class TestHasher:
         token = get_hash(52.0)
         assert all(c in string.hexdigits for c in token)
 
+    def test_date(self):
+        token = get_hash(pd.Timestamp("20240531"))
+        assert all(c in string.hexdigits for c in token)
+
     def test_seq(self):
         token = get_hash([1, "hi", 5.0], ("foo", 3))
         assert all(c in string.hexdigits for c in token)


### PR DESCRIPTION
## Summary
Add helpers for a calendar dataset an idp. It also modifies autopilot to add a calendar id if provided

## Rationale


### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
