### PR TITLE
wait for rmv build

### DIFF
--- a/tests/integration/test_registered_model_versions.py
+++ b/tests/integration/test_registered_model_versions.py
@@ -107,7 +107,7 @@ def custom_model_version(
 ):
     with cleanup_dr(f"customModels/{custom_model}/versions/"):
         yield get_or_create_custom_model_version(
-            dr_endpoint, dr_token, custom_model, sklearn_drop_in_env, folder_path
+            dr_endpoint, dr_token, custom_model, base_environment_id=sklearn_drop_in_env, folder_path=folder_path
         )
 
 

--- a/tests/integration/test_registered_model_versions.py
+++ b/tests/integration/test_registered_model_versions.py
@@ -107,7 +107,11 @@ def custom_model_version(
 ):
     with cleanup_dr(f"customModels/{custom_model}/versions/"):
         yield get_or_create_custom_model_version(
-            dr_endpoint, dr_token, custom_model, base_environment_id=sklearn_drop_in_env, folder_path=folder_path
+            dr_endpoint,
+            dr_token,
+            custom_model,
+            base_environment_id=sklearn_drop_in_env,
+            folder_path=folder_path,
         )
 
 


### PR DESCRIPTION
## Summary
Wait for registered model builds as needed before returning; difficult to do at deployment time as a registered model id is not provided

## Rationale
https://datarobot.slack.com/archives/CNPG5975J/p1718125054951019

### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
