### PR TITLE
draft - support bytes for path dataset

### DIFF
--- a/src/datarobotx/idp/common/path_dataset.py
+++ b/src/datarobotx/idp/common/path_dataset.py
@@ -119,23 +119,22 @@ class PathDataset(AbstractVersionedDataset):  # type: ignore
 
     def _save(
         self,
-        data: Union[  # type: ignore
-            Path, str, tempfile.TemporaryDirectory[Any], tempfile.NamedTemporaryFile, bytes
-        ],
+        data: Union[Path, str, tempfile.TemporaryDirectory[Any], bytes],
     ) -> None:
+        f = None
         if isinstance(data, str):
             path = Path(data)
         elif isinstance(data, Path):
             path = data
+        elif isinstance(data, tempfile.TemporaryDirectory):
+            path = Path(data.name)
         elif isinstance(data, bytes):
-            f = tempfile.NamedTemporaryFile(delete=False)  # required on windows to be able to copy
+            f = tempfile.NamedTemporaryFile(
+                delete=False
+            )  # delete must be False on windows to allow copying
             f.write(data)
             f.flush()
             path = Path(f.name)
-        elif hasattr(
-            data, "name"
-        ):  # tempfile does not support isinstance checks https://bugs.python.org/issue33762
-            path = Path(data.name)
 
         assert path.is_file() or path.is_dir(), "Provided path must be a file or directory."
 
@@ -147,9 +146,10 @@ class PathDataset(AbstractVersionedDataset):  # type: ignore
             self._fs.copy(str(path), save_path)
         else:
             self._fs.copy(str(path / "*"), save_path, recursive=True)
-        if hasattr(data, "close"):
+
+        if f is not None:
             # cleanup NamedTemporaryFile
-            data.close()
+            f.close()
         self._invalidate_cache()
 
     def _exists(self) -> bool:

--- a/src/datarobotx/idp/common/path_dataset.py
+++ b/src/datarobotx/idp/common/path_dataset.py
@@ -119,9 +119,9 @@ class PathDataset(AbstractVersionedDataset):  # type: ignore
 
     def _save(
         self,
-        data: Union[
+        data: Union[  # type: ignore
             Path, str, tempfile.TemporaryDirectory[Any], tempfile.NamedTemporaryFile, bytes
-        ],  # type: ignore
+        ],
     ) -> None:
         if isinstance(data, str):
             path = Path(data)

--- a/tests/unit/test_path_dataset.py
+++ b/tests/unit/test_path_dataset.py
@@ -12,7 +12,7 @@
 # https://www.datarobot.com/wp-content/uploads/2021/07/DataRobot-Tool-and-Utility-Agreement.pdf
 
 from pathlib import Path
-from shutil import copy, copytree
+from shutil import copytree
 import tempfile
 
 from kedro.io import DataCatalog
@@ -33,7 +33,7 @@ def pathlib_path(request, tmp_path):
         return p, request.param
 
 
-@pytest.fixture(params=["path", "str", "tempdir", "tempfile", "bytes"])
+@pytest.fixture(params=["path", "str", "tempdir", "bytes"])
 def asset_path(request, pathlib_path):
     path, save_type = pathlib_path
     if request.param == "path":
@@ -42,19 +42,12 @@ def asset_path(request, pathlib_path):
         return str(path.resolve())
     elif request.param == "tempdir" and save_type == "file":
         pytest.skip("cannot save tempdir as a file")
-    elif request.param == "tempfile" and save_type == "folder":
-        pytest.skip("cannot save tempfile as a folder")
+    elif request.param == "bytes" and save_type == "folder":
+        pytest.skip("cannot save bytes as a folder")
     elif request.param == "tempdir":
         d = tempfile.TemporaryDirectory()
         copytree(path, d.name, dirs_exist_ok=True)
         return d
-    elif request.param == "tempfile":
-        f = tempfile.NamedTemporaryFile()
-        copy(path, f.name)
-        f.flush()
-        return f
-    elif request.param == "bytes" and save_type == "folder":
-        pytest.skip("cannot save bytes as a folder")
     elif request.param == "bytes":
         return path.read_bytes()
 

--- a/tests/unit/test_path_dataset.py
+++ b/tests/unit/test_path_dataset.py
@@ -33,7 +33,7 @@ def pathlib_path(request, tmp_path):
         return p, request.param
 
 
-@pytest.fixture(params=["path", "str", "tempdir", "tempfile"])
+@pytest.fixture(params=["path", "str", "tempdir", "tempfile", "bytes"])
 def asset_path(request, pathlib_path):
     path, save_type = pathlib_path
     if request.param == "path":
@@ -53,6 +53,10 @@ def asset_path(request, pathlib_path):
         copy(path, f.name)
         f.flush()
         return f
+    elif request.param == "bytes" and save_type == "folder":
+        pytest.skip("cannot save bytes as a folder")
+    elif request.param == "bytes":
+        return path.read_bytes()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
windows doesn't play well with NamedTemporaryDirectory; we can probably just return bytes directly from these custom nodes instead to avoid the issue altogether (and less boilerplate in the custom node)

## Rationale


### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
