### PR TITLE
Lukas/use_gitignore

### DIFF
--- a/docker/linter/Dockerfile
+++ b/docker/linter/Dockerfile
@@ -16,6 +16,6 @@ RUN pip install --no-cache-dir -r dev-requirements.txt -r project-requirements.t
 
 # Copy configs for linters
 COPY ./docker/linter/configs/ /root/.config/linter/
-
+RUN git config --global --add safe.directory '*'
 # Set PATH for linting script
 ENV PATH="${WORKDIR}:${PATH}"


### PR DESCRIPTION
## Summary
Use .gitignore to remove files from linting

## Rationale
having extra files in the repo (like build, .venv, etc) will have the linter complain for some reason. This fixes that

### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
