### PR TITLE
Update for retraining_policy.py

### DIFF
--- a/src/datarobotx/idp/retraining_policies.py
+++ b/src/datarobotx/idp/retraining_policies.py
@@ -27,8 +27,8 @@ def _configure_retraining_settings(
     deployment: dr.Deployment = dr.Deployment.get(deployment_id=deployment_id)  # type: ignore
     prediction_env_id = deployment.default_prediction_server["id"]
 
-    if retraining_user_id is None:
-        retraining_user_id = deployment.owners.get("preview")[0].get("id")
+    user_info = client.request(method="GET", url="account/info")
+    retraining_user_id = json.loads(user_info.text)["uid"]
 
     get_payload = {
         "datasetId": dataset_id,
@@ -80,7 +80,6 @@ def get_update_or_create_retraining_policy(
     deployment_id: str,
     name: str,
     dataset_id: Optional[str] = None,
-    retraining_user_id: Optional[str] = None,
     **kwargs: Any,
 ) -> str:
     """Update or create a retraining policy for a model deployment.
@@ -107,7 +106,7 @@ def get_update_or_create_retraining_policy(
     client = dr.Client(token=token, endpoint=endpoint)  # type: ignore
 
     if dataset_id:
-        _configure_retraining_settings(dataset_id, deployment_id, client, retraining_user_id)
+        _configure_retraining_settings(dataset_id, deployment_id, client)
 
     policy_payload_to_upload = {"name": name, **kwargs}
 

--- a/tests/integration/test_retraining_policies.py
+++ b/tests/integration/test_retraining_policies.py
@@ -158,7 +158,7 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
     policy_data = json.loads(get_response.text)
     assert policy_data["featureListStrategy"] == "informative_features"
 
-    retraining_id = get_update_or_create_retraining_policy(
+    retraining_id_1 = get_update_or_create_retraining_policy(
         endpoint=dr_endpoint,
         token=dr_token,
         deployment_id=deployment_id,
@@ -167,7 +167,7 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
     )
 
     retraining_response_1 = client.get(
-        f"deployments/{deployment_id}/retrainingPolicies/{retraining_id}"
+        f"deployments/{deployment_id}/retrainingPolicies/{retraining_id_1}"
     ).json()
 
     retraining_id_2 = get_update_or_create_retraining_policy(
@@ -183,3 +183,43 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
     ).json()
 
     assert retraining_response_1 == retraining_response_2
+
+    autopilotOptions = {
+        "blendBestModels": False,
+        "mode": "quick",
+        "shapOnlyMode": False,
+        "runLeakageRemovedFeatureList": True,
+    }
+    trigger = {
+        "type": "accuracy_decline",
+        "schedule": {
+            "minute": [0],
+            "hour": [0],
+            "dayOfMonth": ["*"],
+            "month": ["*"],
+            "dayOfWeek": ["*"],
+        },
+        "statusDeclinesToWarning": True,
+        "statusDeclinesToFailing": False,
+        "statusStillInDecline": False,
+    }
+    featureListStrategy = "informative_features"
+    projectOptionsStrategy = "same_as_champion"
+
+    retraining_id = get_update_or_create_retraining_policy(
+        endpoint=dr_endpoint,
+        token=dr_token,
+        deployment_id=deployment_id,
+        name="Full Retraining Policy",
+        dataset_id=dataset,
+        trigger=trigger,
+        autopilotOptions=autopilotOptions,
+        featureListStrategy=featureListStrategy,
+        projectOptionsStrategy=projectOptionsStrategy,
+    )
+
+    retraining_response = client.get(
+        f"deployments/{deployment_id}/retrainingPolicies/{retraining_id}"
+    )
+
+    assert retraining_response.status_code == 200


### PR DESCRIPTION
## Summary
Ran into behavior unforeseen when creating the helper in retraining_policies.py. If the [retrainingUser](https://docs.datarobot.com/en/docs/api/reference/public-api/deployments.html#schemaretrainingsettingsupdate) is not supplied, it allows the creation of the retrainingSettings, and it also allows retrainingPolicies to be created as long as they don't have a trigger (all of my tests had no trigger). 

However, this function may not be introducing logic which may not adhere to the way in which DataRobot GUI works (because it's mostly using the REST API). I know we want the repo to mostly be a wrapper on the Python SDK, so looking for a second opinion.

Things to think about:
- If dataset_id is passed in we update the retrainingSettings... This makes sense to me because you may want to retrain on a different dataset (perhaps the dataset you were using got deleted?... IDK)
            - Then, if retraining_user_id is not supplied, the retrainingSettings will be updated with the ID of the first owner on the deployment. This could introduce unexpected behavior. It could be a potential customer?



## Rationale


### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
