### PR TITLE
Hashing Support for File List

### DIFF
--- a/src/datarobotx/idp/common/hashing.py
+++ b/src/datarobotx/idp/common/hashing.py
@@ -81,7 +81,15 @@ def get_hash(*args: Any, **kwargs: Any) -> str:
                         for chunk in iter(lambda: f.read(8192), b""):
                             arg = get_hash(chunk, arg)
             arg = arg.encode("utf-8")
-
+        elif isinstance(arg, list):
+            hash_list = arg
+            arg = ""
+            for i in hash_list:
+                if Path(i).exists():
+                    arg += get_hash(Path(arg))
+                else:
+                    arg += get_hash(arg)
+            arg = arg.encode("utf-8")
         elif callable(arg):
             arg = inspect.getsource(arg).encode("utf-8")
         elif isinstance(arg, pd.DataFrame):

--- a/src/datarobotx/idp/common/hashing.py
+++ b/src/datarobotx/idp/common/hashing.py
@@ -32,6 +32,8 @@ TRUNCATE_HASH_TO = 7
 
 _NONE_REPRESENTATION = 0xFCA86420
 
+ALLOWED_FILE_TYPES = [".zip", ".py", ".java", ".js", ".ts", ".tar.gz", ".tar", ".json", ".yaml", ".txt", ".csv"]
+
 
 def int_to_bytes(number: int) -> bytes:
     """Get bytes representation of an int.
@@ -52,6 +54,10 @@ def get_hash(*args: Any, **kwargs: Any) -> str:
         elif arg is None:
             arg = int_to_bytes(_NONE_REPRESENTATION)
         elif isinstance(arg, str):
+            for t in ALLOWED_FILE_TYPES:
+                if t in arg:
+                    if Path(arg).exists():
+                        arg = get_hash(Path(arg))
             arg = arg.encode("utf-8")
         elif isinstance(arg, int):
             arg = int_to_bytes(arg)
@@ -80,15 +86,6 @@ def get_hash(*args: Any, **kwargs: Any) -> str:
                     with open(os.path.join(root, filename), "rb") as f:
                         for chunk in iter(lambda: f.read(8192), b""):
                             arg = get_hash(chunk, arg)
-            arg = arg.encode("utf-8")
-        elif isinstance(arg, list):
-            hash_list = arg
-            arg = ""
-            for i in hash_list:
-                if Path(i).exists():
-                    arg += get_hash(Path(arg))
-                else:
-                    arg += get_hash(arg)
             arg = arg.encode("utf-8")
         elif callable(arg):
             arg = inspect.getsource(arg).encode("utf-8")

--- a/src/datarobotx/idp/custom_model_versions.py
+++ b/src/datarobotx/idp/custom_model_versions.py
@@ -189,5 +189,6 @@ def get_or_create_custom_model_version(
         token=token,
         custom_model_id=custom_model_id,
         runtime_parameter_values=runtime_parameter_values,
+        args_to_hash=kwargs.get("files", None), 
         **kwargs,
     )


### PR DESCRIPTION
## Summary
When calculating a hash value for a custom model version, drx.idp uses a cascade of logic to generate the hash for comparison. However, this logic is dependent on a "folder_path" argument. When the user submits a list of files `folder_path` is null and such the file contents are not hashed. 

## Rationale
Passing a list a of files explicitly is often easier than passing a folder path. `drx.idp` doesn't have a system list `.gitignore` or `.dockerignore` so extranous files liek venvs or caches get uploaded which can be quite large. 

## Implementation
Per https://datarobot-public-api-client.readthedocs-hosted.com/en/v3.5.0/autodoc/api_reference.html#datarobot.CustomModelVersion.create_clean the correct input is actually a list of tuples. 

This list will be processed by `get_hash` as follows:

1. the list will match as a "Sequence". the arguments will then be spread into `get_hash` individually.
2. the input tuple arguments will match as a "Mapping" then 
3. the values of the tuple mapping will match as a string. NEW_LOGIN And if the string is any of the allowed ALLOWED_FILE_TYPES then they will be converted to a PATH and if that path exists.
4. get_has is called on that path. 
