### PR TITLE
adding max_wait parameters

### DIFF
--- a/src/datarobotx/idp/__init__.py
+++ b/src/datarobotx/idp/__init__.py
@@ -5,5 +5,3 @@ Idempotent functions and helpers for predictive and generative AI tasks.
 
 Ready for use in your orchestration layer of choice.
 """
-
-DEFAULT_MAX_WAIT = 30 * 60  # 30 minutes

--- a/src/datarobotx/idp/__init__.py
+++ b/src/datarobotx/idp/__init__.py
@@ -5,3 +5,5 @@ Idempotent functions and helpers for predictive and generative AI tasks.
 
 Ready for use in your orchestration layer of choice.
 """
+
+DEFAULT_MAX_WAIT = 30 * 60  # 30 minutes

--- a/src/datarobotx/idp/autopilot.py
+++ b/src/datarobotx/idp/autopilot.py
@@ -174,16 +174,16 @@ def get_or_create_autopilot_run(
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
 
     # pull out arguments that are not relevant for hashing
-    max_wait_create_from_dataset = None
-    max_wait_analyze_and_model = None
+    max_wait_create_from_dataset = DEFAULT_MAX_WAIT
+    max_wait_analyze_and_model = DEFAULT_MAX_WAIT
     worker_count_analyze_and_model = None
 
     if create_from_dataset_config is not None:
-        max_wait_create_from_dataset = create_from_dataset_config.get("max_wait", DEFAULT_MAX_WAIT)
+        max_wait_create_from_dataset = create_from_dataset_config.pop("max_wait", DEFAULT_MAX_WAIT)
 
     if analyze_and_model_config is not None:
-        max_wait_analyze_and_model = analyze_and_model_config.get("max_wait", DEFAULT_MAX_WAIT)
-        worker_count_analyze_and_model = analyze_and_model_config.get("worker_count", None)
+        max_wait_analyze_and_model = analyze_and_model_config.pop("max_wait", DEFAULT_MAX_WAIT)
+        worker_count_analyze_and_model = analyze_and_model_config.pop("worker_count", None)
 
     project_config_token = get_hash(
         name,

--- a/src/datarobotx/idp/autopilot.py
+++ b/src/datarobotx/idp/autopilot.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import datarobot as dr
 
-from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 from datarobotx.idp.projects import get_or_create_project_from_dataset
 
@@ -174,15 +173,19 @@ def get_or_create_autopilot_run(
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
 
     # pull out arguments that are not relevant for hashing
-    max_wait_create_from_dataset = DEFAULT_MAX_WAIT
-    max_wait_analyze_and_model = DEFAULT_MAX_WAIT
+    max_wait_create_from_dataset = dr.enums.DEFAULT_MAX_WAIT
+    max_wait_analyze_and_model = dr.enums.DEFAULT_MAX_WAIT
     worker_count_analyze_and_model = None
 
     if create_from_dataset_config is not None:
-        max_wait_create_from_dataset = create_from_dataset_config.pop("max_wait", DEFAULT_MAX_WAIT)
+        max_wait_create_from_dataset = create_from_dataset_config.pop(
+            "max_wait", dr.enums.DEFAULT_MAX_WAIT
+        )
 
     if analyze_and_model_config is not None:
-        max_wait_analyze_and_model = analyze_and_model_config.pop("max_wait", DEFAULT_MAX_WAIT)
+        max_wait_analyze_and_model = analyze_and_model_config.pop(
+            "max_wait", dr.enums.DEFAULT_MAX_WAIT
+        )
         worker_count_analyze_and_model = analyze_and_model_config.pop("worker_count", None)
 
     project_config_token = get_hash(

--- a/src/datarobotx/idp/custom_applications.py
+++ b/src/datarobotx/idp/custom_applications.py
@@ -20,7 +20,6 @@ from datarobot.utils import camelize
 from datarobot.utils.pagination import unpaginate
 from datarobot.utils.waiters import wait_for_async_resolution
 
-from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 
 
@@ -33,7 +32,7 @@ def _create_custom_app(
     **kwargs: Any,
 ) -> str:
     client = dr.Client(endpoint=endpoint, token=token)  # type: ignore[attr-defined]
-    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    max_wait = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     body = {"name": name}
     if environment_id is not None:
         body["environmentId"] = environment_id
@@ -123,6 +122,9 @@ def get_replace_or_create_custom_app(
         If both environment_id and custom_application_source_version_id are provided or if neither is provided.
 
     """
+    # temporarily remove for hashing
+    max_wait = kwargs.pop("max_wait", None)
+
     # test if environment_id xor custom_application_source_version_id is provided
     if bool(environment_id) == bool(custom_application_source_version_id):
         raise ValueError(
@@ -145,6 +147,8 @@ def get_replace_or_create_custom_app(
     except KeyError:
         pass
 
+    if max_wait is not None:
+        kwargs["max_wait"] = max_wait
     return _create_custom_app(
         endpoint=endpoint,
         token=token,
@@ -215,7 +219,7 @@ def get_or_create_qanda_app(
     str
         The ID of the Q&A app.
     """
-    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    max_wait = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     app_token = get_hash(name, deployment_id, environment_id)
 
     client = dr.Client(endpoint=endpoint, token=token)  # type: ignore

--- a/src/datarobotx/idp/custom_applications.py
+++ b/src/datarobotx/idp/custom_applications.py
@@ -20,6 +20,7 @@ from datarobot.utils import camelize
 from datarobot.utils.pagination import unpaginate
 from datarobot.utils.waiters import wait_for_async_resolution
 
+from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 
 
@@ -32,6 +33,7 @@ def _create_custom_app(
     **kwargs: Any,
 ) -> str:
     client = dr.Client(endpoint=endpoint, token=token)  # type: ignore[attr-defined]
+    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
     body = {"name": name}
     if environment_id is not None:
         body["environmentId"] = environment_id
@@ -48,7 +50,7 @@ def _create_custom_app(
     app_url = wait_for_async_resolution(
         dr.Client(token=token, endpoint=endpoint),  # type: ignore[attr-defined]
         status_location,
-        max_wait=30 * 60,
+        max_wait=max_wait,
     )
     return str(app_url).split("/")[-2]
 
@@ -191,11 +193,7 @@ def get_replace_or_create_custom_app_from_env(
 
 
 def get_or_create_qanda_app(
-    endpoint: str,
-    token: str,
-    deployment_id: str,
-    environment_id: str,
-    name: str,
+    endpoint: str, token: str, deployment_id: str, environment_id: str, name: str, **kwargs
 ) -> str:
     """Get or create a Q&A app.
 
@@ -217,6 +215,7 @@ def get_or_create_qanda_app(
     str
         The ID of the Q&A app.
     """
+    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
     app_token = get_hash(name, deployment_id, environment_id)
 
     client = dr.Client(endpoint=endpoint, token=token)  # type: ignore
@@ -229,22 +228,32 @@ def get_or_create_qanda_app(
     except:
         pass
 
-    quanda_app_response = client.post(
+    initial_resp = client.post(
         "customApplications/qanda/",
         json={"deploymentId": deployment_id, "environmentId": environment_id},
     ).json()
 
+    if not initial_resp:
+        handle_http_error(initial_resp)
+
+    status_location = initial_resp.headers["location"]
+    _ = wait_for_async_resolution(
+        dr.Client(token=token, endpoint=endpoint),  # type: ignore[attr-defined]
+        status_location,
+        max_wait=max_wait,
+    )
+
     client.patch(
-        f"customApplications/{quanda_app_response['id']}",
+        f"customApplications/{initial_resp['id']}",
         json={
             "name": f"{name} [{app_token}]",
         },
     )
     client.patch(
-        f"customApplicationSources/{quanda_app_response['customApplicationSourceId']}/",
+        f"customApplicationSources/{initial_resp['customApplicationSourceId']}/",
         json={
             "name": f"{name} [{app_token}]",
         },
     )
 
-    return str(quanda_app_response["id"])
+    return str(initial_resp["id"])

--- a/src/datarobotx/idp/custom_applications.py
+++ b/src/datarobotx/idp/custom_applications.py
@@ -193,7 +193,7 @@ def get_replace_or_create_custom_app_from_env(
 
 
 def get_or_create_qanda_app(
-    endpoint: str, token: str, deployment_id: str, environment_id: str, name: str, **kwargs
+    endpoint: str, token: str, deployment_id: str, environment_id: str, name: str, **kwargs: Any
 ) -> str:
     """Get or create a Q&A app.
 

--- a/src/datarobotx/idp/custom_model_llm_validation.py
+++ b/src/datarobotx/idp/custom_model_llm_validation.py
@@ -17,8 +17,6 @@ from typing import Any, Tuple, Union
 import datarobot as dr
 from datarobot.models.genai.custom_model_llm_validation import CustomModelLLMValidation
 
-from datarobotx.idp import DEFAULT_MAX_WAIT
-
 
 def _find_existing_validation(
     max_wait: int,
@@ -76,7 +74,7 @@ def get_update_or_create_custom_model_llm_validation(
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore
     name = kwargs.pop("name", None)
-    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    max_wait = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     if name is None:
         deployment = dr.Deployment.get(deployment_id)  # type: ignore
         name = f'{deployment.label}: "{prompt_column_name}" -> "{target_column_name}"'

--- a/src/datarobotx/idp/custom_model_versions.py
+++ b/src/datarobotx/idp/custom_model_versions.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Union
 import datarobot as dr
 
 from datarobotx.idp.common.hashing import get_hash
+from datarobotx.idp import DEFAULT_MAX_WAIT
 
 try:
     from datarobot.models.runtime_parameters import RuntimeParameterValue
@@ -86,7 +87,7 @@ def _get_or_create(
 
     dr.Client(token=token, endpoint=endpoint)  # type: ignore
     folder_path = kwargs.pop("folder_path", None)
-    max_wait = kwargs.pop("max_wait", 20 * 60)
+    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
     model_version_token = get_hash(
         Path(folder_path) if folder_path is not None else None,
         custom_model_id,

--- a/src/datarobotx/idp/custom_model_versions.py
+++ b/src/datarobotx/idp/custom_model_versions.py
@@ -17,8 +17,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import datarobot as dr
 
-from datarobotx.idp.common.hashing import get_hash
 from datarobotx.idp import DEFAULT_MAX_WAIT
+from datarobotx.idp.common.hashing import get_hash
 
 try:
     from datarobot.models.runtime_parameters import RuntimeParameterValue

--- a/src/datarobotx/idp/custom_model_versions.py
+++ b/src/datarobotx/idp/custom_model_versions.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import datarobot as dr
 
-from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 
 try:
@@ -87,7 +86,7 @@ def _get_or_create(
 
     dr.Client(token=token, endpoint=endpoint)  # type: ignore
     folder_path = kwargs.pop("folder_path", None)
-    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    max_wait = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     model_version_token = get_hash(
         Path(folder_path) if folder_path is not None else None,
         custom_model_id,

--- a/src/datarobotx/idp/custom_model_versions.py
+++ b/src/datarobotx/idp/custom_model_versions.py
@@ -86,7 +86,7 @@ def _get_or_create(
 
     dr.Client(token=token, endpoint=endpoint)  # type: ignore
     folder_path = kwargs.pop("folder_path", None)
-
+    max_wait = kwargs.pop("max_wait", 20 * 60)
     model_version_token = get_hash(
         Path(folder_path) if folder_path is not None else None,
         custom_model_id,
@@ -111,7 +111,7 @@ def _get_or_create(
         env_version = create(
             custom_model_id,
             folder_path=folder_path,
-            max_wait=20 * 60,
+            max_wait=max_wait,
             runtime_parameter_values=runtime_parameter_values_objs,
             **kwargs,
         )

--- a/src/datarobotx/idp/deployments.py
+++ b/src/datarobotx/idp/deployments.py
@@ -19,6 +19,7 @@ import requests
 import datarobot as dr
 from datarobot.rest import handle_http_error
 
+from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 
 
@@ -63,6 +64,7 @@ def get_or_create_deployment_from_registered_model_version(
     parameters and registered model version.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
+    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
     deployment_token = get_hash(registered_model_version_id, label, **kwargs)
 
     try:
@@ -72,6 +74,7 @@ def get_or_create_deployment_from_registered_model_version(
         deployment = dr.Deployment.create_from_registered_model_version(  # type: ignore[attr-defined]
             registered_model_version_id,
             label,
+            max_wait=max_wait,
             **kwargs,
         )
         return str(deployment.id)
@@ -98,6 +101,7 @@ def get_replace_or_create_deployment_from_registered_model(
     model version is different from what is already deployed.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
+    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
     deployment_token = get_hash(registered_model_name, label, **kwargs)
 
     try:
@@ -108,7 +112,9 @@ def get_replace_or_create_deployment_from_registered_model(
         ) = _lookup_registered_model_version(endpoint, token, curr_deployment_id)
         if registered_model_version_id != curr_registered_model_version_id:
             dr.Deployment.get(curr_deployment_id).perform_model_replace(  # type: ignore[attr-defined]
-                new_registered_model_version_id=registered_model_version_id, reason=reason
+                new_registered_model_version_id=registered_model_version_id,
+                reason=reason,
+                max_wait=max_wait,
             )
         return curr_deployment_id
     except KeyError:
@@ -116,6 +122,7 @@ def get_replace_or_create_deployment_from_registered_model(
         deployment = dr.Deployment.create_from_registered_model_version(  # type: ignore[attr-defined]
             registered_model_version_id,
             label,
+            max_wait=max_wait,
             **kwargs,
         )
         return str(deployment.id)

--- a/src/datarobotx/idp/deployments.py
+++ b/src/datarobotx/idp/deployments.py
@@ -19,7 +19,6 @@ import requests
 import datarobot as dr
 from datarobot.rest import handle_http_error
 
-from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 
 
@@ -64,7 +63,7 @@ def get_or_create_deployment_from_registered_model_version(
     parameters and registered model version.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
-    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    max_wait = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     deployment_token = get_hash(registered_model_version_id, label, **kwargs)
 
     try:
@@ -101,7 +100,7 @@ def get_replace_or_create_deployment_from_registered_model(
     model version is different from what is already deployed.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
-    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    max_wait = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     deployment_token = get_hash(registered_model_name, label, **kwargs)
 
     try:

--- a/src/datarobotx/idp/registered_model_versions.py
+++ b/src/datarobotx/idp/registered_model_versions.py
@@ -20,6 +20,7 @@ from datarobot.models.model_registry.registered_model_version import (
     ExternalTarget,
 )
 
+from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 
 
@@ -31,7 +32,7 @@ def _find_existing_registered_model(registered_model_name: str) -> RegisteredMod
 
 
 def _await_registered_model_build(
-    registered_model_version: RegisteredModelVersion, timeout_secs: int = 600
+    registered_model_version: RegisteredModelVersion, max_wait: int = 600
 ) -> None:
     """Wait for a complete registered model version build status before returning.
 
@@ -53,7 +54,7 @@ def _await_registered_model_build(
                 "failed to build"
             )
             raise RuntimeError(msg)
-        elif waited_secs > timeout_secs:
+        elif waited_secs > max_wait:
             msg = (
                 "Timed out waiting for build for "
                 f"registered model version '{registered_model_version.id}' "
@@ -82,7 +83,7 @@ def get_or_create_registered_custom_model_version(
     argument to specify the maximum time to wait for the registered model version to build.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
-    timeout_seconds = kwargs.pop("max_wait", 600)
+    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
     model_version_token = get_hash(custom_model_version_id, registered_model_name, **kwargs)
 
     try:
@@ -90,7 +91,7 @@ def get_or_create_registered_custom_model_version(
         for model_version in existing_model.list_versions():
             description = model_version.model_description["description"]
             if description is not None and model_version_token in description:
-                _await_registered_model_build(model_version, timeout_seconds)
+                _await_registered_model_build(model_version, max_wait)
                 return str(model_version.id)  # Return existing, matching version
         # Create incremental registered version
         kwargs["registered_model_id"] = existing_model.id
@@ -103,7 +104,7 @@ def get_or_create_registered_custom_model_version(
         custom_model_version_id,
         **kwargs,
     )
-    _await_registered_model_build(model_version, timeout_seconds)
+    _await_registered_model_build(registered_model_version=model_version, max_wait=max_wait)
     return str(model_version.id)
 
 
@@ -177,7 +178,7 @@ def get_or_create_registered_leaderboard_model_version(
     argument to specify the maximum time to wait for the registered model version to build.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
-    timeout_seconds = kwargs.pop("max_wait", 600)
+    timeout_seconds = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
     model_version_token = get_hash(model_id, registered_model_name, **kwargs)
 
     try:

--- a/src/datarobotx/idp/registered_model_versions.py
+++ b/src/datarobotx/idp/registered_model_versions.py
@@ -20,7 +20,6 @@ from datarobot.models.model_registry.registered_model_version import (
     ExternalTarget,
 )
 
-from datarobotx.idp import DEFAULT_MAX_WAIT
 from datarobotx.idp.common.hashing import get_hash
 
 
@@ -83,7 +82,7 @@ def get_or_create_registered_custom_model_version(
     argument to specify the maximum time to wait for the registered model version to build.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
-    max_wait = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    max_wait = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     model_version_token = get_hash(custom_model_version_id, registered_model_name, **kwargs)
 
     try:
@@ -178,7 +177,7 @@ def get_or_create_registered_leaderboard_model_version(
     argument to specify the maximum time to wait for the registered model version to build.
     """
     dr.Client(token=token, endpoint=endpoint)  # type: ignore[attr-defined]
-    timeout_seconds = kwargs.pop("max_wait", DEFAULT_MAX_WAIT)
+    timeout_seconds = kwargs.pop("max_wait", dr.enums.DEFAULT_MAX_WAIT)
     model_version_token = get_hash(model_id, registered_model_name, **kwargs)
 
     try:

--- a/tests/integration/test_autopilot.py
+++ b/tests/integration/test_autopilot.py
@@ -11,6 +11,7 @@
 # Released under the terms of DataRobot Tool and Utility Agreement.
 # https://www.datarobot.com/wp-content/uploads/2021/07/DataRobot-Tool-and-Utility-Agreement.pdf
 
+from copy import deepcopy
 import uuid
 
 import pandas as pd
@@ -194,6 +195,24 @@ def test_get_or_create_autopilot_run(
     )
 
     assert project_id_1 == project_id_2
+
+    analyze_and_model_config_max_wait = deepcopy(analyze_and_model_config)
+    analyze_and_model_config_max_wait["max_wait"] = 1234
+
+    project_id_2_max_wait = get_or_create_autopilot_run(
+        dr_endpoint,
+        dr_token,
+        "pytest autopilot",
+        dataset,
+        analyze_and_model_config=analyze_and_model_config_max_wait,
+        datetime_partitioning_config=datetime_partitioning_config,
+        feature_settings_config=feature_settings_config,
+        advanced_options_config=advanced_options_config,
+        use_case=use_case,
+        calendar_id=calendar_from_dataset,
+    )
+
+    assert project_id_1 == project_id_2_max_wait
 
     advanced_options_config["seed"] = 43
 

--- a/tests/integration/test_custom_applications.py
+++ b/tests/integration/test_custom_applications.py
@@ -311,6 +311,15 @@ def test_get_or_create_from_app_source(
     )
     assert custom_app_id_1 == custom_app_id_2
 
+    custom_app_id_2_max_wait = get_replace_or_create_custom_app(
+        endpoint=dr_endpoint,
+        token=dr_token,
+        name=custom_app_name.format(i=1),
+        custom_application_source_version_id=custom_application_source_version,
+        max_wait=1000,
+    )
+    assert custom_app_id_1 == custom_app_id_2_max_wait
+
     custom_app_id_3 = get_replace_or_create_custom_app(
         endpoint=dr_endpoint,
         token=dr_token,

--- a/tests/integration/test_custom_model_deployments.py
+++ b/tests/integration/test_custom_model_deployments.py
@@ -27,8 +27,8 @@ from datarobotx.idp.registered_model_versions import get_or_create_registered_cu
 def custom_model(cleanup_dr, dr_endpoint, dr_token):
     with cleanup_dr("customModels/"):
         yield get_or_create_custom_model(
-            dr_endpoint,
-            dr_token,
+            endpoint=dr_endpoint,
+            token=dr_token,
             name="pytest custom model",
             target_type="Regression",
             target_name="foo",
@@ -41,7 +41,11 @@ def custom_model_version(
 ):
     with cleanup_dr(f"customModels/{custom_model}/versions/"):
         yield get_or_create_custom_model_version(
-            dr_endpoint, dr_token, custom_model, sklearn_drop_in_env, folder_path
+            endpoint=dr_endpoint,
+            token=dr_token,
+            custom_model_id=custom_model,
+            base_environment_id=sklearn_drop_in_env,
+            folder_path=folder_path,
         )
 
 
@@ -61,7 +65,10 @@ def registered_model_version(
 ):
     with cleanup_dr("registeredModels/"):
         yield get_or_create_registered_custom_model_version(
-            dr_endpoint, dr_token, custom_model_version, registered_model_name
+            endpoint=dr_endpoint,
+            token=dr_token,
+            custom_model_version_id=custom_model_version,
+            registered_model_name=registered_model_name,
         )
 
 
@@ -80,28 +87,28 @@ def test_get_or_create(
     deployment_name,
 ):
     deployment_1 = get_or_create_deployment_from_registered_model_version(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert len(deployment_1)
 
     deployment_2 = get_or_create_deployment_from_registered_model_version(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 == deployment_2
 
     deployment_3 = get_or_create_deployment_from_registered_model_version(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        deployment_name.format(i=2),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        label=deployment_name.format(i=2),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 != deployment_3
@@ -120,42 +127,42 @@ def test_get_create_or_replace(
     deployment_name,
 ):
     deployment_1 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        registered_model_name,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert len(deployment_1)
 
     deployment_2 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        registered_model_name,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 == deployment_2
 
     custom_model_version_2 = get_or_create_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model,
-        sklearn_drop_in_env,
-        folder_path,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_id=custom_model,
+        base_environment_id=sklearn_drop_in_env,
+        folder_path=folder_path,
         maximum_memory=4096 * 1024 * 1024,
     )
     registered_model_version_2 = get_or_create_registered_custom_model_version(
         dr_endpoint, dr_token, custom_model_version_2, registered_model_name
     )
     deployment_3 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version_2,
-        registered_model_name,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version_2,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     # swapping in a new registered model version replaces deployment instead of creating new
@@ -169,11 +176,11 @@ def test_get_create_or_replace(
 
     # but changes other than updating registered model version always create a new deployment
     deployment_4 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version_2,
-        registered_model_name,
-        deployment_name.format(i=2),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version_2,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=2),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 != deployment_4

--- a/tests/integration/test_custom_model_llm_validation.py
+++ b/tests/integration/test_custom_model_llm_validation.py
@@ -165,6 +165,17 @@ def test_get_or_create_custom_model_llm_validation(
     )
     assert validation_id == validation_id_2
 
+    # test that max_wait doesn't affect hash
+    validation_id_2_max_wait = get_update_or_create_custom_model_llm_validation(
+        endpoint=dr_endpoint,
+        token=dr_token,
+        prompt_column_name="question",
+        target_column_name="answer",
+        deployment_id=deployment,
+        max_wait=1000,
+    )
+    assert validation_id == validation_id_2_max_wait
+
     # updates in place if validation for this deployment already exist
     validation_id_3 = get_update_or_create_custom_model_llm_validation(
         endpoint=dr_endpoint,

--- a/tests/integration/test_custom_model_versions.py
+++ b/tests/integration/test_custom_model_versions.py
@@ -158,9 +158,9 @@ def test_get_or_create(
     assert len(model_ver_id_1)
 
     model_ver_id_2 = get_or_create_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_id=custom_model,
         base_environment_id=sklearn_drop_in_env,
         folder_path=folder_path_with_metadata_and_reqs,
     )
@@ -168,9 +168,9 @@ def test_get_or_create(
 
     # test that max_wait doesn't affect the hash
     model_ver_id_2_max_wait = get_or_create_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_id=custom_model,
         base_environment_id=sklearn_drop_in_env,
         folder_path=folder_path_with_metadata_and_reqs,
         max_wait=1000,
@@ -178,9 +178,9 @@ def test_get_or_create(
     assert model_ver_id_1 == model_ver_id_2_max_wait
 
     model_ver_id_3 = get_or_create_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_id=custom_model,
         base_environment_id=sklearn_drop_in_env,
         folder_path=folder_path_with_metadata_and_reqs,
         maximum_memory=4096 * 1024 * 1024,
@@ -188,9 +188,9 @@ def test_get_or_create(
     assert model_ver_id_1 != model_ver_id_3
 
     model_ver_id_4 = get_or_create_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_id=custom_model,
         base_environment_id=sklearn_drop_in_env,
         folder_path=folder_path_with_metadata_and_reqs,
         runtime_parameter_values=pythonic_runtime_parameters,

--- a/tests/integration/test_custom_model_versions.py
+++ b/tests/integration/test_custom_model_versions.py
@@ -166,6 +166,17 @@ def test_get_or_create(
     )
     assert model_ver_id_1 == model_ver_id_2
 
+    # test that max_wait doesn't affect the hash
+    model_ver_id_2_max_wait = get_or_create_custom_model_version(
+        dr_endpoint,
+        dr_token,
+        custom_model,
+        base_environment_id=sklearn_drop_in_env,
+        folder_path=folder_path_with_metadata_and_reqs,
+        max_wait=1000,
+    )
+    assert model_ver_id_1 == model_ver_id_2_max_wait
+
     model_ver_id_3 = get_or_create_custom_model_version(
         dr_endpoint,
         dr_token,

--- a/tests/integration/test_datarobot_model_deployments.py
+++ b/tests/integration/test_datarobot_model_deployments.py
@@ -41,9 +41,9 @@ def analyze_and_model_config():
 def use_case(dr_endpoint, dr_token, cleanup_dr):
     with cleanup_dr("useCases/"):
         yield get_or_create_use_case(
-            dr_endpoint,
-            dr_token,
-            "pytest use case",
+            endpoint=dr_endpoint,
+            token=dr_token,
+            name="pytest use case",
         )
 
 
@@ -62,9 +62,9 @@ def df():
 def dataset(dr_endpoint, dr_token, df, use_case, cleanup_dr):
     with cleanup_dr("datasets/", id_attribute="datasetId"):
         yield get_or_create_dataset_from_df(
-            dr_endpoint,
-            dr_token,
-            use_case_id=use_case,
+            endpoint=dr_endpoint,
+            token=dr_token,
+            use_cases=use_case,
             name="pytest_test_autopilot_dataset",
             data_frame=df,
         )
@@ -74,10 +74,10 @@ def dataset(dr_endpoint, dr_token, df, use_case, cleanup_dr):
 def autopilot_model(dr_endpoint, dr_token, use_case, dataset, analyze_and_model_config, cleanup_dr):
     with cleanup_dr("projects/", paginated=False):
         yield get_or_create_autopilot_run(
-            dr_endpoint,
-            dr_token,
-            "pytest autopilot",
-            dataset,
+            endpoint=dr_endpoint,
+            token=dr_token,
+            name="pytest autopilot",
+            dataset_id=dataset,
             analyze_and_model_config=analyze_and_model_config,
             use_case=use_case,
         )
@@ -109,7 +109,10 @@ def registered_model_version(
 ):
     with cleanup_dr("registeredModels/"):
         yield get_or_create_registered_leaderboard_model_version(
-            dr_endpoint, dr_token, recommended_model, registered_model_name
+            endpoint=dr_endpoint,
+            token=dr_token,
+            model_id=recommended_model,
+            registered_model_name=registered_model_name,
         )
 
 
@@ -128,28 +131,28 @@ def test_get_or_create(
     deployment_name,
 ):
     deployment_1 = get_or_create_deployment_from_registered_model_version(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert len(deployment_1)
 
     deployment_2 = get_or_create_deployment_from_registered_model_version(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 == deployment_2
 
     deployment_3 = get_or_create_deployment_from_registered_model_version(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        deployment_name.format(i=2),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        label=deployment_name.format(i=2),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 != deployment_3
@@ -166,21 +169,21 @@ def test_get_create_or_replace(
     cleanup_deployments,
 ):
     deployment_1 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        registered_model_name,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert len(deployment_1)
 
     deployment_2 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version,
-        registered_model_name,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 == deployment_2
@@ -189,11 +192,11 @@ def test_get_create_or_replace(
         dr_endpoint, dr_token, other_model, registered_model_name
     )
     deployment_3 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version_2,
-        registered_model_name,
-        deployment_name.format(i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version_2,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=1),
         default_prediction_server_id=default_prediction_server_id,
     )
     # swapping in a new registered model version replaces deployment instead of creating new
@@ -207,11 +210,11 @@ def test_get_create_or_replace(
 
     # but changes other than updating registered model version always create a new deployment
     deployment_4 = get_replace_or_create_deployment_from_registered_model(
-        dr_endpoint,
-        dr_token,
-        registered_model_version_2,
-        registered_model_name,
-        deployment_name.format(i=2),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        registered_model_version_id=registered_model_version_2,
+        registered_model_name=registered_model_name,
+        label=deployment_name.format(i=2),
         default_prediction_server_id=default_prediction_server_id,
     )
     assert deployment_1 != deployment_4

--- a/tests/integration/test_registered_model_versions.py
+++ b/tests/integration/test_registered_model_versions.py
@@ -227,6 +227,16 @@ def test_get_or_create_from_leaderboard(
     )
     assert model_1 == model_2
 
+    # test that max_wait doesn't affect the hash
+    model_2_max_wait = get_or_create_registered_leaderboard_model_version(
+        dr_endpoint,
+        dr_token,
+        recommended_model,
+        registered_model_name.format(source="datarobot", i=1),
+        max_wait=1000,
+    )
+    assert model_1 == model_2_max_wait
+
     model_3 = get_or_create_registered_leaderboard_model_version(
         dr_endpoint,
         dr_token,

--- a/tests/integration/test_registered_model_versions.py
+++ b/tests/integration/test_registered_model_versions.py
@@ -186,7 +186,6 @@ def test_get_or_create_external(
         name="pytest external registered model version #1",
         target=external_model_target,
         registered_model_name=registered_external_model_name,
-        max_wait=1800,
     )
     assert len(model_1)
 
@@ -196,7 +195,6 @@ def test_get_or_create_external(
         name="pytest external registered model version #1",
         target=external_model_target,
         registered_model_name=registered_external_model_name,
-        max_wait=1800,
     )
     assert model_1 == model_2
     model_2_max_wait = get_or_create_registered_external_model_version(
@@ -205,7 +203,7 @@ def test_get_or_create_external(
         name="pytest external registered model version #1",
         target=external_model_target,
         registered_model_name=registered_external_model_name,
-        max_wait=1801,
+        max_wait=1234,
     )
     assert model_1 == model_2_max_wait
 
@@ -215,7 +213,6 @@ def test_get_or_create_external(
         name="pytest external registered model version #2",
         target=external_model_target,
         registered_model_name=registered_external_model_name,
-        max_wait=1800,
     )
     assert model_1 != model_3
 

--- a/tests/integration/test_registered_model_versions.py
+++ b/tests/integration/test_registered_model_versions.py
@@ -42,9 +42,9 @@ def analyze_and_model_config():
 def use_case(dr_endpoint, dr_token, cleanup_dr):
     with cleanup_dr("useCases/"):
         yield get_or_create_use_case(
-            dr_endpoint,
-            dr_token,
-            "pytest use case #1",
+            endpoint=dr_endpoint,
+            token=dr_token,
+            name="pytest use case #1",
         )
 
 
@@ -63,9 +63,9 @@ def df():
 def dataset(dr_endpoint, dr_token, df, use_case, cleanup_dr):
     with cleanup_dr("datasets/", id_attribute="datasetId"):
         yield get_or_create_dataset_from_df(
-            dr_endpoint,
-            dr_token,
-            use_case_id=use_case,
+            endpoint=dr_endpoint,
+            token=dr_token,
+            use_cases=use_case,
             name="pytest_test_autopilot_dataset",
             data_frame=df,
         )
@@ -75,10 +75,10 @@ def dataset(dr_endpoint, dr_token, df, use_case, cleanup_dr):
 def autopilot_model(dr_endpoint, dr_token, use_case, dataset, analyze_and_model_config, cleanup_dr):
     with cleanup_dr("projects/", paginated=False):
         yield get_or_create_autopilot_run(
-            dr_endpoint,
-            dr_token,
-            "pytest autopilot",
-            dataset,
+            endpoint=dr_endpoint,
+            token=dr_token,
+            name="pytest autopilot",
+            dataset_id=dataset,
             analyze_and_model_config=analyze_and_model_config,
             use_case=use_case,
         )
@@ -93,8 +93,8 @@ def recommended_model(autopilot_model, cleanup_dr):
 def custom_model(cleanup_dr, dr_endpoint, dr_token):
     with cleanup_dr("customModels/"):
         yield get_or_create_custom_model(
-            dr_endpoint,
-            dr_token,
+            endpoint=dr_endpoint,
+            token=dr_token,
             name="pytest custom model",
             target_type="Regression",
             target_name="foo",
@@ -107,9 +107,9 @@ def custom_model_version(
 ):
     with cleanup_dr(f"customModels/{custom_model}/versions/"):
         yield get_or_create_custom_model_version(
-            dr_endpoint,
-            dr_token,
-            custom_model,
+            endpoint=dr_endpoint,
+            token=dr_token,
+            custom_model_id=custom_model,
             base_environment_id=sklearn_drop_in_env,
             folder_path=folder_path,
         )
@@ -135,18 +135,18 @@ def test_get_or_create_from_custom_model(
     dr_endpoint, dr_token, cleanup_registered_models, custom_model_version, registered_model_name
 ):
     model_1 = get_or_create_registered_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model_version,
-        registered_model_name.format(source="custom", i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_version_id=custom_model_version,
+        registered_model_name=registered_model_name.format(source="custom", i=1),
     )
     assert len(model_1)
 
     model_2 = get_or_create_registered_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model_version,
-        registered_model_name.format(source="custom", i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_version_id=custom_model_version,
+        registered_model_name=registered_model_name.format(source="custom", i=1),
     )
     assert model_1 == model_2
 
@@ -159,10 +159,10 @@ def test_get_or_create_from_custom_model(
     assert model_1 != model_3
 
     model_4 = get_or_create_registered_custom_model_version(
-        dr_endpoint,
-        dr_token,
-        custom_model_version,
-        registered_model_name.format(source="custom", i=2),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        custom_model_version_id=custom_model_version,
+        registered_model_name=registered_model_name.format(source="custom", i=2),
         description="New description",
     )
     assert model_3 != model_4
@@ -181,29 +181,41 @@ def test_get_or_create_external(
     registered_external_model_name = registered_model_name.format(source="external", i=1)
 
     model_1 = get_or_create_registered_external_model_version(
-        dr_endpoint,
-        dr_token,
-        "pytest external registered model version #1",
-        external_model_target,
-        registered_external_model_name,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        name="pytest external registered model version #1",
+        target=external_model_target,
+        registered_model_name=registered_external_model_name,
+        max_wait=1800,
     )
     assert len(model_1)
 
     model_2 = get_or_create_registered_external_model_version(
-        dr_endpoint,
-        dr_token,
-        "pytest external registered model version #1",
-        external_model_target,
-        registered_external_model_name,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        name="pytest external registered model version #1",
+        target=external_model_target,
+        registered_model_name=registered_external_model_name,
+        max_wait=1800,
     )
     assert model_1 == model_2
+    model_2_max_wait = get_or_create_registered_external_model_version(
+        endpoint=dr_endpoint,
+        token=dr_token,
+        name="pytest external registered model version #1",
+        target=external_model_target,
+        registered_model_name=registered_external_model_name,
+        max_wait=1801,
+    )
+    assert model_1 == model_2_max_wait
 
     model_3 = get_or_create_registered_external_model_version(
-        dr_endpoint,
-        dr_token,
-        "pytest external registered model version #2",
-        external_model_target,
-        registered_external_model_name,
+        endpoint=dr_endpoint,
+        token=dr_token,
+        name="pytest external registered model version #2",
+        target=external_model_target,
+        registered_model_name=registered_external_model_name,
+        max_wait=1800,
     )
     assert model_1 != model_3
 
@@ -212,35 +224,35 @@ def test_get_or_create_from_leaderboard(
     dr_endpoint, dr_token, cleanup_registered_models, recommended_model, registered_model_name
 ):
     model_1 = get_or_create_registered_leaderboard_model_version(
-        dr_endpoint,
-        dr_token,
-        recommended_model,
-        registered_model_name.format(source="datarobot", i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        model_id=recommended_model,
+        registered_model_name=registered_model_name.format(source="datarobot", i=1),
     )
     assert len(model_1)
 
     model_2 = get_or_create_registered_leaderboard_model_version(
-        dr_endpoint,
-        dr_token,
-        recommended_model,
-        registered_model_name.format(source="datarobot", i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        model_id=recommended_model,
+        registered_model_name=registered_model_name.format(source="datarobot", i=1),
     )
     assert model_1 == model_2
 
     # test that max_wait doesn't affect the hash
     model_2_max_wait = get_or_create_registered_leaderboard_model_version(
-        dr_endpoint,
-        dr_token,
-        recommended_model,
-        registered_model_name.format(source="datarobot", i=1),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        model_id=recommended_model,
+        registered_model_name=registered_model_name.format(source="datarobot", i=1),
         max_wait=1000,
     )
     assert model_1 == model_2_max_wait
 
     model_3 = get_or_create_registered_leaderboard_model_version(
-        dr_endpoint,
-        dr_token,
-        recommended_model,
-        registered_model_name.format(source="datarobot", i=2),
+        endpoint=dr_endpoint,
+        token=dr_token,
+        model_id=recommended_model,
+        registered_model_name=registered_model_name.format(source="datarobot", i=2),
     )
     assert model_1 != model_3


### PR DESCRIPTION
## Summary
Pulling out max_wait arguments from kwargs for most relevant helpers

## Rationale
support max_wait parameter where it hasn't been supported. Also ensure changing max_wait doesn't affect the hash - waiting is not relevant for idempotency

### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
