### PR TITLE
add dependabot action

### DIFF
--- a/.github/workflows/check_security.yml
+++ b/.github/workflows/check_security.yml
@@ -1,0 +1,15 @@
+name: 'Check Security Updates'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+


### PR DESCRIPTION
## Summary
add dependabot security updates validation to github actions

## Rationale
validate PRs with dependabot

### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
