### PR TITLE
support serverless retraining

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 
 from hashlib import sha256
 import os
+import uuid
 
 import pytest
 
@@ -56,6 +57,28 @@ def dr_endpoint():
 def default_prediction_server_id():
     """DR prediction server id."""
     return "5f06612df1740600260aca72"
+
+
+@pytest.fixture()
+def serverless_prediction_environment():
+    short_uuid = str(uuid.uuid4())[:5]
+    import datarobot as dr
+
+    prediction_environment = dr.PredictionEnvironment.create(
+        platform=dr.enums.PredictionEnvironmentPlatform.DATAROBOT_SERVERLESS,
+        name=f"pytest {short_uuid}",
+    )
+    return prediction_environment.id
+
+
+@pytest.fixture(params=["serverless", "dpe"])
+def prediction_environment_id(
+    request, serverless_prediction_environment, default_prediction_server_id
+):
+    if request.param == "serverless":
+        return serverless_prediction_environment
+    else:
+        return default_prediction_server_id
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,8 @@ def serverless_prediction_environment():
         platform=dr.enums.PredictionEnvironmentPlatform.DATAROBOT_SERVERLESS,
         name=f"pytest {short_uuid}",
     )
-    return prediction_environment.id
+    yield prediction_environment.id
+    prediction_environment.delete()
 
 
 @pytest.fixture(params=["serverless", "dpe"])

--- a/tests/integration/test_retraining_policies.py
+++ b/tests/integration/test_retraining_policies.py
@@ -114,7 +114,7 @@ def deployment_id(
     cleanup_dr,
     registered_model_version,
     registered_model_name,
-    default_prediction_server_id,
+    prediction_environment_id,
     dr_endpoint,
     dr_token,
 ):
@@ -124,11 +124,13 @@ def deployment_id(
             token=dr_token,
             registered_model_version_id=registered_model_version,
             label=registered_model_name,
-            default_prediction_server_id=default_prediction_server_id,
+            prediction_environment_id=prediction_environment_id,
         )
 
 
-def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
+def test_retraining_policy(
+    dr_endpoint, dr_token, deployment_id, dataset, prediction_environment_id
+):
     # Can we create policy
     retraining_id_1 = get_update_or_create_retraining_policy(
         endpoint=dr_endpoint,
@@ -136,6 +138,7 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
         deployment_id=deployment_id,
         name="post_test",
         dataset_id=dataset,
+        prediction_environment_id=prediction_environment_id,
         featureListStrategy="same_as_champion",
     )
 
@@ -146,6 +149,7 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
         deployment_id=deployment_id,
         name="post_test",
         dataset_id=dataset,
+        prediction_environment_id=prediction_environment_id,
         featureListStrategy="informative_features",
     )
     assert retraining_id_1 == retraining_id_2
@@ -164,6 +168,7 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
         deployment_id=deployment_id,
         name="idempotency test (no changes in API background)",
         dataset_id=dataset,
+        prediction_environment_id=prediction_environment_id,
     )
 
     retraining_response_1 = client.get(
@@ -176,6 +181,7 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
         deployment_id=deployment_id,
         name="idempotency test (no changes in API background)",
         dataset_id=dataset,
+        prediction_environment_id=prediction_environment_id,
     )
 
     retraining_response_2 = client.get(
@@ -212,6 +218,7 @@ def test_retraining_policy(dr_endpoint, dr_token, deployment_id, dataset):
         deployment_id=deployment_id,
         name="Full Retraining Policy",
         dataset_id=dataset,
+        prediction_environment_id=prediction_environment_id,
         trigger=trigger,
         autopilotOptions=autopilotOptions,
         featureListStrategy=featureListStrategy,


### PR DESCRIPTION
## Summary
add new optional argument prediction_environment_id to get_update_or_create_retraining_policy

## Rationale
if using this function with serverless deployment it fails

### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
