### PR TITLE
Update datastore.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datarobotx-idp"
-version = "0.2.13"
+version = "0.2.14"
 requires-python = ">=3.8"
 description = "Suite of utilities for idempotent creation of DataRobot assets"
 readme = "README.md"

--- a/src/datarobotx/idp/datastore.py
+++ b/src/datarobotx/idp/datastore.py
@@ -20,7 +20,7 @@ import datarobot as dr
 
 
 def _find_existing_datastore(canonical_name: str) -> str:
-    dss = dr.DataStore.list()  # type: ignore
+    dss = dr.DataStore.list(typ='all')  # type: ignore
     datastore = [
         ds for ds in dss if ds.canonical_name is not None and ds.canonical_name == canonical_name
     ][0]

--- a/src/datarobotx/idp/datastore.py
+++ b/src/datarobotx/idp/datastore.py
@@ -20,7 +20,7 @@ import datarobot as dr
 
 
 def _find_existing_datastore(canonical_name: str) -> str:
-    dss = dr.DataStore.list(typ='all')  # type: ignore
+    dss = dr.DataStore.list(typ="all")  # type: ignore
     datastore = [
         ds for ds in dss if ds.canonical_name is not None and ds.canonical_name == canonical_name
     ][0]


### PR DESCRIPTION
## Summary
Datastore only lists all of the available datastores via jdbc connection by default  for some reason. This change makes it list everything.

## Rationale


### Note: This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, etc.
